### PR TITLE
Fails to execute sub-command with -i or -w option

### DIFF
--- a/mem.py
+++ b/mem.py
@@ -91,8 +91,13 @@ if __name__=="__main__":
     signal.signal(signal.SIGINT, print_report)
     signal.signal(signal.SIGTERM, print_report)
 
-    proc = subprocess.Popen(sub_command)
-    proc_path = "/proc/" + str(proc.pid) + "/status"
+    try:
+        proc = subprocess.Popen(sub_command)
+        proc_path = "/proc/" + str(proc.pid) + "/status"
+
+    except OSError as e:
+        print(sys.argv[0] + ': cannot run ' + sub_command[0] + ': ' + e.strerror)
+        exit(1)
 
     watch_file = open(args.watch, 'w') if args.watch is not None else None
     begin_time = time.time()


### PR DESCRIPTION
In case sub command requires -i or -w option.
This is because these options are also used in `mem.py`, so it fails to parse command arguments.

```
% mem.py echo -i asdfasdf
usage: mem.py [-h] [--interval INTERVAL] [--watch FILENAME]
              [sub_command [sub_command ...]]
mem.py: error: argument --interval/-i: invalid int value: 'asdfasdf'
```

As a provisional avoidance, surround with double quote (").

```
% mem.py "echo -i asdfasdf"
-i asdfasdf
echo -i asdfasdf  VmPeak: 4.3MB  VmHWM: 188.0kB  user: 0.03s  system: 0.03s  total: 0.10s
```
